### PR TITLE
refactor: completion stream readable

### DIFF
--- a/chatgpt.go
+++ b/chatgpt.go
@@ -101,7 +101,7 @@ func CompletionStream(prompt string, cfg *CompletionConfig) error {
 				break
 			}
 
-			if chatGptStream.Choices[0].FinishReason == "stop" {
+		if isStreamStopped(chatGptStream) {
 				done <- struct{}{}
 				break
 			}
@@ -121,8 +121,18 @@ func CompletionStream(prompt string, cfg *CompletionConfig) error {
 			return e
 		case <-time.After(1 * time.Minute):
 			return errors.New("context deadline exceeded")
+func isStreamStopped(chatGptStream ChatGptStream) bool {
+	stopReasons := []string{"stop", "length"}
+	finishReason := chatGptStream.Choices[0].FinishReason
+
+	for _, stopReason := range stopReasons {
+		if finishReason == stopReason {
+			fmt.Println()
+			log.Printf("Completion is stopped due to [%s]\n", stopReason)
+			return true
 		}
 	}
+	return false
 }
 
 // SendMessage Request to OpenAI API and return *http.Response

--- a/chatgpt_test.go
+++ b/chatgpt_test.go
@@ -1,6 +1,7 @@
 package chatgpt_go
 
 import (
+	"bytes"
 	"fmt"
 	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/assert"
@@ -8,7 +9,7 @@ import (
 )
 
 func TestCompletion(t *testing.T) {
-	result, err := Completion("report for google", &CompletionConfig{
+	result, err := Completion("report about google", &CompletionConfig{
 		MaxTokens: Int(50),
 	})
 	assert.NoError(t, err)
@@ -17,8 +18,8 @@ func TestCompletion(t *testing.T) {
 }
 
 func TestCompletionStream(t *testing.T) {
-	err := CompletionStream("report for google", &CompletionConfig{
-		MaxTokens: Int(50),
+	err := CompletionStream("report about google", &CompletionConfig{
+		MaxTokens: Int(150),
 	})
 	fmt.Println()
 	assert.NoError(t, err)
@@ -28,7 +29,7 @@ func TestSuffixWhenStream(t *testing.T) {
 	str := `data: {"id": "cmpl-6gBfRPRNIyt5s47Y1BH0W1B4lEWdj", "object": "text_completion", "created": 1675512645, "choices": [{"text": "", "index": 0, "logprobs": null, "finish_reason": "stop"}], "model": "text-davinci-003"}`
 
 	var m ChatGptStream
-	err := json.Unmarshal([]byte(str[5:]), &m)
+	err := json.Unmarshal(bytes.TrimPrefix([]byte(str), []byte(`data: `)), &m)
 
 	assert.NoError(t, err)
 	assert.Greater(t, len(m.Choices), 0)

--- a/types.go
+++ b/types.go
@@ -111,9 +111,3 @@ type ChatGptStream struct {
 type BaseErrorResponse struct {
 	message *string
 }
-
-func NewBaseErrorResponse(msg *string) *BaseErrorResponse {
-	return &BaseErrorResponse{
-		message: msg,
-	}
-}


### PR DESCRIPTION
[refactor: openai api stream의 stop reason case 추가 및 정리](https://github.com/choshsh/chatgpt-go/pull/2/commits/713958b44731c80374552de24f1c5a356b0fa101)

[reafctor: stream 함수 가독성 향상](https://github.com/choshsh/chatgpt-go/pull/2/commits/c0206354bfe8c1443b743ceeeac3f0ed99c5bf53)